### PR TITLE
make the 'sign into slack' button underline

### DIFF
--- a/components/slack.js
+++ b/components/slack.js
@@ -186,7 +186,9 @@ export default ({ index, progress, setProgress, github }) => (
               }}
             />
             <p style={{ opacity: 0.5, marginTop: 0 }}>:smug-dino:</p>
-            <p>
+            <p style={{
+              textDecoration: "underline"
+            }}>
               Click here to sign into{" "}
               <img
                 src="slack.svg"


### PR DESCRIPTION
it is not obvious that the text is a clickable link and so making it underline captures the attention of people better
fixes #24 